### PR TITLE
Check clear session 3

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_training/screen/weather_screen.dart';
+import 'package:flutter_training/screen/home_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: const WeatherScreen(),
+      home: const HomeScreen(),
     );
   }
 }

--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -23,7 +23,7 @@ class _HomeScreenState extends State<HomeScreen> {
     }
     await Navigator.push(
       context,
-      MaterialPageRoute<dynamic>(
+      MaterialPageRoute<void>(
         builder: (context) => const WeatherScreen(),
       ),
     );

--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -16,15 +16,18 @@ class _HomeScreenState extends State<HomeScreen> {
     WidgetsBinding.instance.endOfFrame.then((_) => loadScreen());
   }
 
-  void loadScreen() {
-    Future.delayed(const Duration(milliseconds: 500), () {
-      Navigator.push(
-        context,
-        MaterialPageRoute<dynamic>(
-          builder: (context) => const WeatherScreen(),
-        ),
-      );
-    });
+  Future<void> loadScreen() async {
+    await Future.delayed(const Duration(milliseconds: 500), () {});
+    if (!mounted) {
+      return;
+    }
+    await Navigator.push(
+      context,
+      MaterialPageRoute<dynamic>(
+        builder: (context) => const WeatherScreen(),
+      ),
+    );
+    await loadScreen();
   }
 
   @override

--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -17,7 +17,7 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Future<void> _loadScreen() async {
-    await Future.delayed(const Duration(milliseconds: 500), () {});
+    await Future<void>.delayed(const Duration(milliseconds: 500));
     if (!mounted) {
       return;
     }

--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_training/screen/weather_screen.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  @override
+  void initState() {
+    super.initState();
+
+    WidgetsBinding.instance.endOfFrame.then((_) => loadScreen());
+  }
+
+  void loadScreen() {
+    Future.delayed(const Duration(milliseconds: 500), () {
+      Navigator.push(
+        context,
+        MaterialPageRoute<dynamic>(
+          builder: (context) => const WeatherScreen(),
+        ),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(backgroundColor: Colors.green);
+  }
+}

--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -13,10 +13,10 @@ class _HomeScreenState extends State<HomeScreen> {
   void initState() {
     super.initState();
 
-    WidgetsBinding.instance.endOfFrame.then((_) => loadScreen());
+    WidgetsBinding.instance.endOfFrame.then((_) => _loadScreen());
   }
 
-  Future<void> loadScreen() async {
+  Future<void> _loadScreen() async {
     await Future.delayed(const Duration(milliseconds: 500), () {});
     if (!mounted) {
       return;
@@ -27,7 +27,7 @@ class _HomeScreenState extends State<HomeScreen> {
         builder: (context) => const WeatherScreen(),
       ),
     );
-    await loadScreen();
+    await _loadScreen();
   }
 
   @override

--- a/lib/screen/weather_screen.dart
+++ b/lib/screen/weather_screen.dart
@@ -15,12 +15,12 @@ class _WeatherScreenState extends State<WeatherScreen> {
   final _weather = YumemiWeather();
   String _weatherImage = '';
 
-  void reloadWeather() {
+  void _reloadWeather() {
     _weatherImage = _weather.fetchSimpleWeather();
     setState(() {});
   }
 
-  void onTapBack() {
+  void _onTapBack() {
     Navigator.of(context).pop();
   }
 
@@ -64,11 +64,11 @@ class _WeatherScreenState extends State<WeatherScreen> {
                     children: [
                       TemperatureButton(
                         text: 'Close',
-                        onPressed: onTapBack,
+                        onPressed: _onTapBack,
                       ),
                       TemperatureButton(
                         text: 'Reload',
-                        onPressed: reloadWeather,
+                        onPressed: _reloadWeather,
                       ),
                     ],
                   ),

--- a/lib/screen/weather_screen.dart
+++ b/lib/screen/weather_screen.dart
@@ -20,6 +20,10 @@ class _WeatherScreenState extends State<WeatherScreen> {
     setState(() {});
   }
 
+  void onTapBack() {
+    Navigator.of(context).pop();
+  }
+
   @override
   Widget build(BuildContext context) {
     final deviceWidthSize = MediaQuery.of(context).size.width / 2;
@@ -60,7 +64,7 @@ class _WeatherScreenState extends State<WeatherScreen> {
                     children: [
                       TemperatureButton(
                         text: 'Close',
-                        onPressed: () {},
+                        onPressed: onTapBack,
                       ),
                       TemperatureButton(
                         text: 'Reload',


### PR DESCRIPTION
## 課題

close #4 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] StatefulWidgetアプリ起動時に新しい画面に遷移する(HomeScreenを作成)
- [x] 新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する(Future.delayedを使用して0.5秒後に処理を行うようにしました。)
- [x] 前回まで作っていた画面の Close ボタンをタップすると画面を閉じる（Navigator.popのメソッドを使用しました。）
- [x] メソッドをPrivateにした。
- [x] 画面を戻った時に再度、0.5秒後に再度、画面遷移できるようにしました。


## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
|   ![](https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/lifecycle/demo.gif?raw=true)   |   <img src=https://user-images.githubusercontent.com/67954894/202946850-99dcfaf8-2ecd-4ee4-9397-0a1f80965d2f.gif  width=320>  |




