### PR TITLE
Check clear session5

### DIFF
--- a/lib/screen/weather_screen.dart
+++ b/lib/screen/weather_screen.dart
@@ -18,10 +18,10 @@ class _WeatherScreenState extends State<WeatherScreen> {
   void _reloadWeather() {
     try {
       _weatherImage = _weather.fetchThrowsWeather('tokyo');
+      setState(() {});
     } on YumemiWeatherError catch (error) {
       _checkError(error);
     }
-    setState(() {});
   }
 
   void _checkError(YumemiWeatherError error) {

--- a/lib/screen/weather_screen.dart
+++ b/lib/screen/weather_screen.dart
@@ -20,11 +20,12 @@ class _WeatherScreenState extends State<WeatherScreen> {
       _weatherImage = _weather.fetchThrowsWeather('tokyo');
       setState(() {});
     } on YumemiWeatherError catch (error) {
-      _convertYumemiWeatherError(error);
+      final errorMessage = _convertYumemiWeatherError(error);
+      _openErrorDialog(errorMessage);
     }
   }
 
-  void _convertYumemiWeatherError(YumemiWeatherError error) {
+  String _convertYumemiWeatherError(YumemiWeatherError error) {
     var errorMessage = '';
     switch (error) {
       case YumemiWeatherError.unknown:
@@ -34,7 +35,7 @@ class _WeatherScreenState extends State<WeatherScreen> {
         errorMessage = 'invalidParameter';
         break;
     }
-    _openErrorDialog(errorMessage);
+    return errorMessage;
   }
 
   void _openErrorDialog(String error) {

--- a/lib/screen/weather_screen.dart
+++ b/lib/screen/weather_screen.dart
@@ -16,8 +16,30 @@ class _WeatherScreenState extends State<WeatherScreen> {
   String _weatherImage = '';
 
   void _reloadWeather() {
-    _weatherImage = _weather.fetchSimpleWeather();
+    try {
+      _weatherImage = _weather.fetchThrowsWeather('tokyo');
+    } on YumemiWeatherError catch (error) {
+      _openErrorDialog(error.toString());
+    }
     setState(() {});
+  }
+
+  void _openErrorDialog(String error) {
+    showDialog<void>(
+      context: context,
+      builder: (_) {
+        return AlertDialog(
+          title: const Text('Error'),
+          content: Text('error is $error'),
+          actions: [
+            TextButton(
+              onPressed: _onTapBack,
+              child: const Text('OK'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   void _onTapBack() {

--- a/lib/screen/weather_screen.dart
+++ b/lib/screen/weather_screen.dart
@@ -19,9 +19,22 @@ class _WeatherScreenState extends State<WeatherScreen> {
     try {
       _weatherImage = _weather.fetchThrowsWeather('tokyo');
     } on YumemiWeatherError catch (error) {
-      _openErrorDialog(error.toString());
+      _checkError(error);
     }
     setState(() {});
+  }
+
+  void _checkError(YumemiWeatherError error) {
+    var errorMessage = '';
+    switch (error) {
+      case YumemiWeatherError.unknown:
+        errorMessage = 'unknown';
+        break;
+      case YumemiWeatherError.invalidParameter:
+        errorMessage = 'invalidParameter';
+        break;
+    }
+    _openErrorDialog(errorMessage);
   }
 
   void _openErrorDialog(String error) {

--- a/lib/screen/weather_screen.dart
+++ b/lib/screen/weather_screen.dart
@@ -20,11 +20,11 @@ class _WeatherScreenState extends State<WeatherScreen> {
       _weatherImage = _weather.fetchThrowsWeather('tokyo');
       setState(() {});
     } on YumemiWeatherError catch (error) {
-      _checkError(error);
+      _convertYumemiWeatherError(error);
     }
   }
 
-  void _checkError(YumemiWeatherError error) {
+  void _convertYumemiWeatherError(YumemiWeatherError error) {
     var errorMessage = '';
     switch (error) {
       case YumemiWeatherError.unknown:

--- a/lib/screen/weather_screen.dart
+++ b/lib/screen/weather_screen.dart
@@ -26,7 +26,7 @@ class _WeatherScreenState extends State<WeatherScreen> {
   }
 
   String _convertYumemiWeatherError(YumemiWeatherError error) {
-    var errorMessage = '';
+    final String errorMessage;
     switch (error) {
       case YumemiWeatherError.unknown:
         errorMessage = 'unknown';


### PR DESCRIPTION
## 課題

close #6 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] 使用する API を `fetchSimpleWeather()` から `fetchThrowsWeather()` に変更する(変更して引数をtokyoにした)
- [x]  API のエラーを補足して、エラーの内容に応じて [AlertDialog] でメッセージを表示する（ダイアログにエラーのメッセージを掲載した）
- [x]  [AlertDialog] の OK ボタンをタップすると、ダイアログを閉じる（閉じる処理については、以前で作成したためそれを使用した）

## 工夫したところ
・エラーメッセージは自由と記載してあったが、実務を意識してエラーの文章をTextに入れました。

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
|  ![](https://github.com/yumemi-inc/flutter-training-template/blob/main/docs/sessions/images/error/demo.gif?raw=true)  | <img src=https://user-images.githubusercontent.com/67954894/204168958-bb329ed6-6093-412a-a5a7-7e7fafa1c2f5.gif  width=320>    |



